### PR TITLE
Fix image update event form

### DIFF
--- a/src/components/event_forms/EventForm.jsx
+++ b/src/components/event_forms/EventForm.jsx
@@ -121,12 +121,13 @@ const EventForm = (props) => {
       description,
       ticketType
     } = formValues;
-
+    console.log('startdatetime', startDatetime);
+    console.log('enddatetime', endDatetime);
     const mutationValues = {
       title,
       description,
-      start: startDatetime.toISOString(),
-      end: endDatetime.toISOString(),
+      start: startDatetime,
+      end: endDatetime,
       placeName,
       streetAddress,
       streetAddress2,
@@ -136,6 +137,7 @@ const EventForm = (props) => {
       tags: selectedTags.length ? selectedTags.map(tag => ({title: tag})) : null,
       ticketType,
       images,
+      eventImages: images && images.length ? [] : undefined
     }
 
     console.log(mutationValues, "mutation values");

--- a/src/components/event_forms/EventForm.jsx
+++ b/src/components/event_forms/EventForm.jsx
@@ -123,8 +123,7 @@ const EventForm = (props) => {
       description,
       ticketType
     } = formValues;
-    console.log('startdatetime', startDatetime);
-    console.log('enddatetime', endDatetime);
+    
     const mutationValues = {
       title,
       description,


### PR DESCRIPTION
This change fixes the issue of images not being removed when uploading a new image in the update event form.  The server will not change the images if the eventImages field is undefined. If an image is being uploaded, an empty array will be sent instead, which will cause any current images tied to the event to be removed since the front end is only using the first image for each event.  The uploaded image will be tied to that event.  In the future when multiple images are being used, the eventImages array will need to include image urls that the user wants to keep, and will omit the image urls that need to be removed when updating.