### PR TITLE
conditional rendering for managing events based on user id, create/up…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7971,6 +7971,11 @@
         "object.assign": "^4.1.0"
       }
     },
+    "jwt-decode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "downshift": "^4.0.7",
     "graphql": "^14.5.8",
     "graphql-tag": "^2.10.1",
+    "jwt-decode": "^2.2.0",
     "moment": "^2.24.0",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,6 +29,7 @@ import PrivateRoute from 'private-route/PrivateRoute'
 import {GetUserPosition} from './utils'
 
 function App() {
+  const decode = require('jwt-decode'); //used to decode access token
   const {
     isLoading,
     user,
@@ -41,7 +42,14 @@ function App() {
   const getAccessToken = async () => {
     try {
       const token = await getTokenSilently()
+      const decodedToken = decode(token);
       setAccessToken(token)
+      cache.writeData({
+        data: {
+          userId: decodedToken['http://cc_id']
+        },
+      })
+
     } catch (err) {
       console.log(err)
     }
@@ -106,6 +114,7 @@ function App() {
       userLongitude: null,
       userAddress: null,
       maxDistance: null,
+      userId: null
     },
   })
 
@@ -116,7 +125,7 @@ function App() {
       <Switch>
         <Route exact path='/' component={Home} />
         <Route path='/create-event' component={CreateEventPage} />
-        <Route path='/events/:id' component={EventView} />
+        <Route exact path='/events/:id' component={EventView} />
         <Route exact path='/events/:id/update' component={UpdateEventPage} />
         <Route path='/search' component={SearchResults} />
         <Route path='/test-page' component={TestPage} />

--- a/src/components/event_forms/CreateEvent.jsx
+++ b/src/components/event_forms/CreateEvent.jsx
@@ -3,7 +3,7 @@ import {useMutation} from '@apollo/react-hooks';
 import {ADD_EVENT} from '../../graphql'
 import EventForm from './EventForm';
 
-export default function CreateEvent() {
+export default function CreateEvent({history}) {
 
   const [addEvent, {data, error}] = useMutation(ADD_EVENT);
 
@@ -12,6 +12,8 @@ export default function CreateEvent() {
       formType="add"
       mutation={addEvent} 
       mutationData={data} 
-      mutationError={error} />
+      mutationError={error} 
+      history={history}
+      />
   )
 }

--- a/src/components/event_forms/EventForm.jsx
+++ b/src/components/event_forms/EventForm.jsx
@@ -152,6 +152,8 @@ const EventForm = (props) => {
   }
   if(mutationData){
     console.log(mutationData);
+    const {id} = mutationData.addEvent || mutationData.updateEvent;
+    props.history.push(`/events/${id}`);
   }
   if(formErrors.length > 0){
     console.log('form errors', formErrors)

--- a/src/components/event_forms/UpdateEvent.jsx
+++ b/src/components/event_forms/UpdateEvent.jsx
@@ -1,16 +1,17 @@
 import React from 'react'
 import {useParams} from 'react-router-dom'
+import {Redirect} from "react-router-dom"
 
 // graphql
 import {useMutation, useQuery} from '@apollo/react-hooks';
-import {GET_EVENT_BY_ID, UPDATE_EVENT} from '../../graphql'
+import {GET_EVENT_BY_ID, UPDATE_EVENT, GET_USER_ID} from '../../graphql'
 
 // components
 import EventForm from './EventForm';
 import LoadingLogo from '../loading/LoadingLogo'
 
 
-export default function UpdateEvent() {
+export default function UpdateEvent({history}) {
   // get event id out of url for query
   const queryParams = useParams()
 
@@ -18,6 +19,8 @@ export default function UpdateEvent() {
   const {data, loading, error} = useQuery(GET_EVENT_BY_ID, {
     variables: {id: queryParams.id},
   })
+
+  const {data: userId} = useQuery(GET_USER_ID);
 
   const [updateEvent, {data: mutationData, error: mutationError}] = useMutation(UPDATE_EVENT);
 
@@ -41,6 +44,10 @@ export default function UpdateEvent() {
 
   // destructure and render event form with initial values if fetch successful
   const item = data.events[0]
+  if(userId && data && data.events[0] && userId.userId !== data.events[0].creator.id){
+    console.log(userId.userId, data.events[0].creator.id)
+    return <Redirect to='/'></Redirect>
+  }
 
   return (
     <EventForm 
@@ -48,6 +55,7 @@ export default function UpdateEvent() {
       item={item}
       mutation={updateEventHandler} 
       mutationData={mutationData} 
-      mutationError={mutationError} />
+      mutationError={mutationError}
+      history={history} />
   )
 }

--- a/src/graphql/events.mutation.js
+++ b/src/graphql/events.mutation.js
@@ -103,3 +103,11 @@ export const UPDATE_EVENT = gql`
       }
     }
   `;
+
+  export const DELETE_EVENT = gql`
+    mutation DeleteEvent($id: ID!){
+      deleteEvent(where: {id: $id}){
+        id
+      }
+    }
+  `

--- a/src/graphql/getUserId.query.js
+++ b/src/graphql/getUserId.query.js
@@ -1,0 +1,9 @@
+import gql from 'graphql-tag'
+
+const GET_USER_ID = gql`
+  query GetCache {
+    userId @client
+  }
+`
+
+export default GET_USER_ID

--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -10,7 +10,7 @@ import {
 import USERS from './users.query.js'
 
 // pure server GraphQL API mutations
-import {ADD_EVENT, UPDATE_EVENT} from './events.mutation.js'
+import {ADD_EVENT, UPDATE_EVENT, DELETE_EVENT} from './events.mutation.js'
 
 // mixed server and client GraphQL API queries
 
@@ -18,6 +18,7 @@ import {ADD_EVENT, UPDATE_EVENT} from './events.mutation.js'
 import {typeDefs} from './localState'
 import USER_LOCATION from './userLocation.query.js'
 import GET_CACHE from './getCache.query.js'
+import GET_USER_ID from './getUserId.query'
 
 // re-export as modules
 export {
@@ -34,10 +35,12 @@ export {
   // server mutations
   ADD_EVENT,
   UPDATE_EVENT,
+  DELETE_EVENT,
 
   // mixed server and client
 
   // pure local state
   typeDefs,
   GET_CACHE,
+  GET_USER_ID
 }

--- a/src/graphql/localState.jsx
+++ b/src/graphql/localState.jsx
@@ -20,5 +20,6 @@ export const typeDefs = gql`
     userLatitude: Float
     userLongitude: Float
     userAddress: String
+    userId: String
   }
 `

--- a/src/pages/CreateEventPage.jsx
+++ b/src/pages/CreateEventPage.jsx
@@ -8,7 +8,7 @@ import {
   banner
 } from './styles/EventFormPage.module.scss'
 
-export default function CreateEventPage() {
+export default function CreateEventPage({history}) {
   return (
     <div className={`${outerContainer}`}>
       <div className={`${innerContainer}`}>
@@ -17,7 +17,7 @@ export default function CreateEventPage() {
             Event Details
           </h3>
         </section>
-        <CreateEvent />
+        <CreateEvent history={history}/>
       </div>
     </div>
   )

--- a/src/pages/EventView.jsx
+++ b/src/pages/EventView.jsx
@@ -6,8 +6,8 @@ import LoadingLogo from '../components/loading/LoadingLogo'
 import {DropdownIcon} from 'icons'
 
 //graphql
-import {useQuery} from '@apollo/react-hooks'
-import {GET_EVENT_BY_ID_WITH_DISTANCE, GET_CACHE} from '../graphql'
+import {useQuery, useMutation} from '@apollo/react-hooks'
+import {GET_EVENT_BY_ID_WITH_DISTANCE, GET_CACHE, GET_USER_ID, DELETE_EVENT} from '../graphql'
 
 import {months, weekDays, buildQS, useDropdown} from '../utils'
 
@@ -29,11 +29,18 @@ import {
 /* Show all of the details and information about an event.
 Users can RSVP to an event from here.
  */
-const EventView = () => {
+const EventView = ({history}) => {
   const queryParams = useParams()
 
   const {data: localCache} = useQuery(GET_CACHE)
+  const {data: userId} = useQuery(GET_USER_ID)
+  const [deleteEvent, {data: deleteData, error: deleteError}] = useMutation(DELETE_EVENT);
   const {userLatitude, userLongitude} = localCache
+
+  if(deleteData){
+    console.log(deleteData);
+    history.push('/');
+  }
 
   // destructure event information passed through props
   const apolloData = useQuery(GET_EVENT_BY_ID_WITH_DISTANCE, {
@@ -164,7 +171,7 @@ const EventView = () => {
         </div>
         <div className={panel_right}>
           {/* Manage Buton, only displays if logged-in user is the event creator  */}
-          <div
+          {userId && creator && userId.userId === creator.id && <div
             className={`dropdown  has-background-danger button ${
               manageIsOpen ? 'is-active' : ''
             }  no-border`}
@@ -191,13 +198,13 @@ const EventView = () => {
             </div>
             <div className='dropdown-menu drop-center w-100' role='menu'>
               <div className='dropdown-content'>
-                <div className='dropdown-item has-text-centered'>Edit</div>
-                <div className='dropdown-item has-text-centered has-text-danger'>
+              <Link to={`/events/${id}/update`}><div className='dropdown-item has-text-centered'>Edit</div></Link>
+                <div onClick={() => {deleteEvent({variables: {id}})}} className='dropdown-item has-text-centered has-text-danger'>
                   Delete
                 </div>
               </div>
             </div>
-          </div>{' '}
+          </div>}{' '}
           {/* end manage dropdown */}
           {/* numbers to be replaced with event information */}
           {/* <div>
@@ -244,9 +251,7 @@ const EventView = () => {
                 {description}
               </p>
               {/* Attend functionality not yet implemented */}
-              <Link to={`${id}/update`}>
-                <button className='button  is-dark'>Update</button>
-              </Link>
+                <button className='button  is-dark'>Attend</button>
             </div>
           </div>
           {/* Appears to right of event info on tablet+ */}

--- a/src/pages/UpdateEventPage.jsx
+++ b/src/pages/UpdateEventPage.jsx
@@ -8,7 +8,7 @@ import {
   banner
 } from './styles/EventFormPage.module.scss'
 
-export default function UpdateEventPage() {
+export default function UpdateEventPage({history}) {
   return (
     <div className={`${outerContainer}`}>
       <div className={`${innerContainer}`}>
@@ -17,7 +17,7 @@ export default function UpdateEventPage() {
             Update Event Details
           </h3>
         </section>
-        <UpdateEvent />
+        <UpdateEvent history={history}/>
       </div>
     </div>
   )


### PR DESCRIPTION
- Installed jwt-decode to decode access token.
- User ID is stored in cache to check if user created an event for conditional rendering of manage event dropdown.
- Dropdown update/delete buttons working.
- Create/update event redirects to event view page upon successful event mutation.
-Delete event button redirects to event list upon successful event deletion.
- Redirect added to update event form which redirects user if user did not create that event.