### PR TITLE
fixes error on multiple pages because of missing dependency in useEffect

### DIFF
--- a/src/components/event_forms/TagInput.jsx
+++ b/src/components/event_forms/TagInput.jsx
@@ -161,7 +161,7 @@ const TagInput = ({
     return () => {
       document.removeEventListener('click', handleClick)
     }
-  }, [])
+  }, [handleClick])
 
   if (loading) {
     return <LoadingDots />


### PR DESCRIPTION
# Description
Adds a missing dependency to the useEffect dependency array in tagInput.jsx that was causing an error when clicking the createEvent tab when already on the create Event page, and also when clearing the filters on the search page. 

Fixes issue #124 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings