### PR TITLE
delete modal radio buttons fixed

### DIFF
--- a/src/components/events/DeleteEventModal.jsx
+++ b/src/components/events/DeleteEventModal.jsx
@@ -12,8 +12,11 @@ import {
   checkboxes,
 } from './styles/DeleteEventModal.module.scss'
 
-function DeleteEventModal({deleteEvent, toggleModal, isSeries}) {
+function DeleteEventModal({deleteEvent, deleteSeries, toggleModal, isSeries}) {
   const [deleteOption, setDeleteOption] = useState('single')
+  const handleDeleteOptionChange = (event) => {
+    setDeleteOption(event.target.value)
+  }
   return isSeries ? (
     <div className={`${deleteEventModal}`}>
       <div className={`${deleteEventModalContent}`}>
@@ -22,30 +25,37 @@ function DeleteEventModal({deleteEvent, toggleModal, isSeries}) {
           <br />
           Would you like to:
           <div className={`${checkboxes}`}>
-            <input
-              onClick={() => setDeleteOption('single')}
-              type='radio'
-              name='delete'
-              value='single'
-              checked
-            />
-            <label> Delete this event</label>
+            <label for='single'>
+              <input
+                onClick={handleDeleteOptionChange}
+                id='single'
+                type='radio'
+                name='delete'
+                value='single'
+                checked={deleteOption === 'single'}
+              />
+              Delete this event
+            </label>
           </div>
           <div className={`${checkboxes}`}>
-            <input
-              onClick={() => setDeleteOption('series')}
-              type='radio'
-              name='delete'
-              value='series'
-            />
-            <label> Delete this series</label>
+            <label for='series'>
+              <input
+                onClick={handleDeleteOptionChange}
+                id='series'
+                type='radio'
+                name='delete'
+                value='series'
+                checked={deleteOption === 'series'}
+              />
+              Delete this series
+            </label>
           </div>
         </div>
       </div>
       <div className={`${deleteEventModalButtonContainer}`}>
         <button
           onClick={() => {
-            deleteEvent()
+            deleteOption === 'single' ? deleteEvent() : deleteSeries()
           }}
           className={`${button} ${yes}`}
         >

--- a/src/pages/EventView.jsx
+++ b/src/pages/EventView.jsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react'
 import {useParams, Link} from 'react-router-dom'
-import moment, {relativeTimeRounding} from 'moment'
+import moment from 'moment'
 import ReactGA from 'react-ga'
 
 // components
@@ -21,13 +21,13 @@ import {
   SAVE_EVENT,
   RSVP_EVENT,
   GET_SERIES,
+  DELETE_SERIES,
 } from '../graphql'
 
-import {months, weekDays, buildQS, createQSObj, useDropdown} from '../utils'
+import {buildQS, createQSObj, useDropdown} from '../utils'
 
 //styles
 import {
-  banner,
   top_sec,
   date_display,
   space_letters,
@@ -46,8 +46,6 @@ import {
   titleH1,
   series,
 } from './styles/EventView.module.scss'
-
-import {set} from 'react-ga'
 
 /* Show all of the details and information about an event.
 Users can RSVP to an event from here.
@@ -73,12 +71,13 @@ const EventView = ({history}) => {
       eventSeries.events[0].series ? setIsSeries(true) : setIsSeries(false)
   }, [eventSeries, isSeries])
 
-  const [
-    deleteEventMutation,
-    {data: deleteData, error: deleteError, loading: deleteLoading},
-  ] = useMutation(DELETE_EVENT)
+  const [deleteEventMutation, {data: deleteData}] = useMutation(DELETE_EVENT)
 
-  if (deleteData) {
+  const [deleteSeriesMutation, {data: deleteSeriesData}] = useMutation(
+    DELETE_SERIES,
+  )
+
+  if (deleteData || deleteSeriesData) {
     history.push('/')
   }
 
@@ -181,14 +180,7 @@ const EventView = ({history}) => {
     tags,
     rsvps,
     ticketPrice,
-    saved,
   } = data.events.length && data.events[0]
-
-  // find out if current user rsvp'd for event
-  const didRsvp =
-    rsvps.length && cacheUserId
-      ? rsvps.filter((rsvpData) => rsvpData.id === cacheUserId.userId)[0]
-      : null
 
   //destructure first item in locations array
   const {
@@ -227,6 +219,11 @@ const EventView = ({history}) => {
 
   const deleteEvent = () => {
     deleteEventMutation({variables: {id}})
+  }
+
+  const deleteSeries = () => {
+    const seriesId = eventSeries.events[0].series.id
+    deleteSeriesMutation({variables: {id: seriesId}})
   }
 
   const saveEvent = () => {
@@ -501,6 +498,7 @@ const EventView = ({history}) => {
       {showModal && (
         <DeleteEventModal
           deleteEvent={deleteEvent}
+          deleteSeries={deleteSeries}
           toggleModal={toggleModal}
           isSeries={isSeries}
         />


### PR DESCRIPTION
# Description
The radio buttons on the delete event modal for events that belong to series now function as intended. This modal only shows up when attempting to delete an event that belongs to a series, and the option to delete an event only deletes the currently selected event, while deleting a series deletes every event in the series. The radio buttons are now easier to select. Variables that were declared but never used were removed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings